### PR TITLE
Scrooge style unions

### DIFF
--- a/scrooge-generator/src/main/resources/nodegen/union.mustache
+++ b/scrooge-generator/src/main/resources/nodegen/union.mustache
@@ -42,7 +42,7 @@ export class {{StructName}} {
             }
 {{#has_fields}}
             switch (fid) {
-                {{#fields}}case {{index}}:
+                {{#fields}}case {{id}}:
                     {{>readField}}
                     break
                 {{/fields}}

--- a/scrooge-generator/src/main/resources/nodegen/union.mustache
+++ b/scrooge-generator/src/main/resources/nodegen/union.mustache
@@ -14,14 +14,19 @@ export class {{StructName}} {
 {{#fields}}
     public {{fieldName}}: {{noNamespaceFieldType}}
 {{/fields}}
+{{#fields}}
+    static {{FieldName}}({{fieldName}}: {{noNamespaceFieldType}}): {{StructName}} {
+        return new {{StructName}}({
+            {{fieldName}}: {{fieldName}}
+        });
+    }
+{{/fields}}
     constructor(args?) {
 {{#has_fields}}
         if (args) {
 {{#fields}}
             if (args.{{fieldName}} !== undefined && args.{{fieldName}} !== null) {
                 this.{{fieldName}} = args.{{fieldName}}
-            } else {
-                throw new Thrift.TProtocolException(Thrift.TProtocolExceptionType.UNKNOWN, 'Required field {{fieldName}} is unset!')
             }
 {{/fields}}
         }


### PR DESCRIPTION
This PR is part feature, part bugfix. 

Bug 1: Unions were being treated as structs with required values. Thus all unions throw a TApplicationException, because union objects only have one of a set of fields defined. Apache Thrift for Node treats unions as structs with optional values, so I've changed the generated code to match that.

Bug 2: Union reads / writes were not using the same field ids. Corrected.

Feature: Added Scala-scrooge-style union construction. Each field in the union set gets its own static constructor on the union object, thus guaranteeing in a typesafe manner that valid unions will be constructed (in other words, exactly one field will be set, and it will be a value of the correct type). See https://twitter.github.io/scrooge/GeneratedCodeUsage.html for scrooge-style union usage.
