### PR TITLE
Fix service imports

### DIFF
--- a/scrooge-generator/src/main/resources/nodegen/service.mustache
+++ b/scrooge-generator/src/main/resources/nodegen/service.mustache
@@ -5,6 +5,8 @@ import {Thrift, Protocol, Transport, Int64, AnyProtocolClass} from 'thrift'
 import { {{StructName}} } from './{{StructName}}'
 {{/structs}}
 
+{{requireStatements}}
+
 {{#syncFunctionStructs}}
 {{#argsStruct}}{{>struct}}{{/argsStruct}}
 {{#resultStruct}}{{>struct}}{{/resultStruct}}

--- a/scrooge-generator/src/main/resources/nodegen/service.mustache
+++ b/scrooge-generator/src/main/resources/nodegen/service.mustache
@@ -1,10 +1,6 @@
 import thrift from 'thrift'
 import {Thrift, Protocol, Transport, Int64, AnyProtocolClass} from 'thrift'
 
-{{#structs}}
-import { {{StructName}} } from './{{StructName}}'
-{{/structs}}
-
 {{requireStatements}}
 
 {{#syncFunctionStructs}}

--- a/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/node/NodeGenerator.scala
+++ b/scrooge-generator/src/main/scala/com/twitter/scrooge/backend/node/NodeGenerator.scala
@@ -244,11 +244,6 @@ class NodeGenerator (
 
     dict.update("requireStatements", requireStatements.mkString("\n"))
 
-    val doc = normalizeCase(resolvedDoc.document)
-    dict("structs") = doc.structs.map { struct =>
-      structDict(struct, Some(namespace), includes, options, true)
-    }
-
     dict
   }
 


### PR DESCRIPTION
Problem

Services do not contain the correct import statements. They import any structs that are within the same thrift file as the service, but are missing imports for external structs.

Solution

Scan the service node in the AST for any struct-like types and import them.

Result

Services will contain imports for the struct-like types they require.
