### PR TITLE
Using published versions of dependencies

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -12,9 +12,15 @@ import scoverage.ScoverageKeys
 
 object Scrooge extends Build {
   val branch = Process("git" :: "rev-parse" :: "--abbrev-ref" :: "HEAD" :: Nil).!!.trim
-  val suffix = if (branch == "master") "" else "-SNAPSHOT"
 
-  val libVersion = "4.13.0" + suffix
+//  TODO: Since Twitter doesn't publish SNAPSHOT dependencies for this project,
+//  we are using non-SNAPSHOT dependencies to make builds easier for now. If we decide
+//  to contribute the node generator back to Scrooge, we can revert this change.
+//
+//  val suffix = if (branch == "master") "" else "-SNAPSHOT"
+//  val libVersion = "4.13.0" + suffix
+  val suffix = ""
+  val libVersion = "4.13.0" + "SNAPSHOT"
 
   // To build the develop branch you need to publish util, and finagle locally:
   // 'git checkout develop; sbt publishLocal' to publish SNAPSHOT versions of these projects.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.13


### PR DESCRIPTION
By default, Scrooge uses SNAPSHOT versions of twitter dependencies when not on the "master" branch. Since twitter doesn't publish SNAPSHOT dependencies, this makes builds very cumbersome. For ease of development on the node tooling going forward, I've fixed twitter dependencies to their release versions, which are already published. When and if the time comes where we'd like to merge this project into the base fork, we can revert this change. 