### PR TITLE
Node thrift typings

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -20,7 +20,7 @@ object Scrooge extends Build {
 //  val suffix = if (branch == "master") "" else "-SNAPSHOT"
 //  val libVersion = "4.13.0" + suffix
   val suffix = ""
-  val libVersion = "4.13.0" + "SNAPSHOT"
+  val libVersion = "4.13.0" + "-SNAPSHOT"
 
   // To build the develop branch you need to publish util, and finagle locally:
   // 'git checkout develop; sbt publishLocal' to publish SNAPSHOT versions of these projects.

--- a/scrooge-generator/src/main/resources/nodegen/service.mustache
+++ b/scrooge-generator/src/main/resources/nodegen/service.mustache
@@ -11,7 +11,7 @@ export class Client {
     private _seqid: number
     public _reqs: {[key: string]: (e?: Error|object, r?: any) => void}
 
-    constructor(public output: Transport, public pClass: {new (trans: TTransport): TProtocol;}) {
+    constructor(public output: TTransport, public pClass: {new (trans: TTransport): TProtocol;}) {
         this._seqid = 0
         this._reqs = {}
     }

--- a/scrooge-generator/src/main/resources/nodegen/service.mustache
+++ b/scrooge-generator/src/main/resources/nodegen/service.mustache
@@ -1,5 +1,4 @@
-import thrift from 'thrift'
-import {Thrift, Protocol, Transport, Int64, AnyProtocolClass} from 'thrift'
+import {Thrift, TProtocol, TTransport, Int64} from 'thrift'
 
 {{requireStatements}}
 
@@ -12,7 +11,7 @@ export class Client {
     private _seqid: number
     public _reqs: {[key: string]: (e?: Error|object, r?: any) => void}
 
-    constructor(public output: Transport, public pClass: AnyProtocolClass) {
+    constructor(public output: Transport, public pClass: {new (trans: TTransport): TProtocol;}) {
         this._seqid = 0
         this._reqs = {}
     }
@@ -57,7 +56,7 @@ export class Client {
         return this.output.flush()
     }
 
-    public recv_{{name}}(input: Protocol, mtype: Thrift.MessageType, rseqid: number): void {
+    public recv_{{name}}(input: TProtocol, mtype: Thrift.MessageType, rseqid: number): void {
         const noop = () => null
         let callback = this._reqs[rseqid] || noop
         delete this._reqs[rseqid]
@@ -93,7 +92,7 @@ export class Processor {
         this._handler = handler
     }
 
-    public process(input: Protocol, output: Protocol) {
+    public process(input: TProtocol, output: TProtocol) {
         const r = input.readMessageBegin()
         if (this["process_" + r.fname]) {
             return this["process_" + r.fname].call(this, r.rseqid, input, output)
@@ -109,7 +108,7 @@ export class Processor {
         }
     }
 
-    {{#syncFunctions}}public process_{{name}}(seqid: number, input: Protocol, output: Protocol) {
+    {{#syncFunctions}}public process_{{name}}(seqid: number, input: TProtocol, output: TProtocol) {
         const args = new {{ServiceName}}{{nameTitleCase}}Args()
         args.read(input)
         input.readMessageEnd()

--- a/scrooge-generator/src/main/resources/nodegen/struct.mustache
+++ b/scrooge-generator/src/main/resources/nodegen/struct.mustache
@@ -4,8 +4,7 @@
 {{#importDoc}}
 {{>importDoc}}
 
-import thrift from 'thrift'
-import {Thrift, Protocol, Int64} from 'thrift'
+import {Thrift, TProtocol, Int64} from 'thrift'
 
 {{requireStatements}}
 {{/importDoc}}
@@ -49,7 +48,7 @@ constructor(args?: I{{StructName}}Args) {
 {{/fields}}
     }
 
-    public read(input: Protocol): void {
+    public read(input: TProtocol): void {
         input.readStructBegin()
         while (true) {
 {{#has_fields}}
@@ -81,7 +80,7 @@ constructor(args?: I{{StructName}}Args) {
         return
     }
 
-    public write(output: Protocol): void {
+    public write(output: TProtocol): void {
         output.writeStructBegin("{{StructName}}")
 {{#fields}}
         if (this.{{fieldName}} != null) {


### PR DESCRIPTION
In order to compile typescript code with proper type checks against the npm thrift library, we need
1. A Thrift typings file
2. Generated code that adheres to the typings

This PR accomplishes (2).