### PR TITLE
Allow request contexts to be passed to thrift methods

### DIFF
--- a/scrooge-generator/src/main/resources/nodegen/service.mustache
+++ b/scrooge-generator/src/main/resources/nodegen/service.mustache
@@ -25,25 +25,18 @@ export class Client {
     }
 
 {{#syncFunctions}}
-    public {{name}}({{#args}}{{fieldName}}: {{fieldType}}, {{/args}}callback: (e?: Error|object, r?: {{typeName}}) => void): void
-    public {{name}}({{#args}}{{fieldName}}: {{fieldType}}, {{/args}}): Promise<{{typeName}}>
-    public {{name}}({{#args}}{{fieldName}}: {{fieldType}}, {{/args}}callback?: (e?: Error|object, r?: {{typeName}}) => void): Promise<{{typeName}}>|void {
+    public {{name}}({{#args}}{{fieldName}}: {{fieldType}}, {{/args}}): Promise<{{typeName}}> {
         this._seqid = this.new_seqid()
-        if (callback instanceof Function) {
-            this._reqs[this.seqid()] = callback
-            this.send_{{name}}({{#args}}{{fieldName}}, {{/args}})
-        } else {
-            return new Promise<{{typeName}}>((resolve, reject) => {
-                this._reqs[this.seqid()] = function(error, result) {
-                    if (error) {
-                        reject(error)
-                    } else {
-                        resolve(result)
-                    }
+        return new Promise<{{typeName}}>((resolve, reject) => {
+            this._reqs[this.seqid()] = function(error, result) {
+                if (error) {
+                    reject(error)
+                } else {
+                    resolve(result)
                 }
-                this.send_{{name}}({{#args}}{{fieldName}}, {{/args}})
-            })
-        }
+            }
+            this.send_{{name}}({{#args}}{{fieldName}}, {{/args}})
+        })
     }
 
     public send_{{name}}({{#args}}{{fieldName}}: {{fieldType}}, {{/args}}): void {

--- a/scrooge-generator/src/main/resources/nodegen/service.mustache
+++ b/scrooge-generator/src/main/resources/nodegen/service.mustache
@@ -78,14 +78,12 @@ export class Client {
     {{/syncFunctions}}
 }
 
-export class Processor {
-    private _handler
+export class Processor<Context> {
 
-    constructor(handler) {
-        this._handler = handler
+    constructor(private _handler) {
     }
 
-    public process(input: TProtocol, output: TProtocol, context?: any) {
+    public process(input: TProtocol, output: TProtocol, context?: Context) {
         const r = input.readMessageBegin()
         if (this["process_" + r.fname]) {
             return this["process_" + r.fname].call(this, r.rseqid, input, output, context)
@@ -101,7 +99,7 @@ export class Processor {
         }
     }
 
-    {{#syncFunctions}}public process_{{name}}(seqid: number, input: TProtocol, output: TProtocol, context?: any) {
+    {{#syncFunctions}}public process_{{name}}(seqid: number, input: TProtocol, output: TProtocol, context?: Context) {
         const args = new {{ServiceName}}{{nameTitleCase}}Args()
         args.read(input)
         input.readMessageEnd()

--- a/scrooge-generator/src/main/resources/nodegen/service.mustache
+++ b/scrooge-generator/src/main/resources/nodegen/service.mustache
@@ -92,10 +92,10 @@ export class Processor {
         this._handler = handler
     }
 
-    public process(input: TProtocol, output: TProtocol) {
+    public process(input: TProtocol, output: TProtocol, context?: any) {
         const r = input.readMessageBegin()
         if (this["process_" + r.fname]) {
-            return this["process_" + r.fname].call(this, r.rseqid, input, output)
+            return this["process_" + r.fname].call(this, r.rseqid, input, output, context)
         } else {
             input.skip(Thrift.Type.STRUCT)
             input.readMessageEnd()
@@ -108,65 +108,45 @@ export class Processor {
         }
     }
 
-    {{#syncFunctions}}public process_{{name}}(seqid: number, input: TProtocol, output: TProtocol) {
+    {{#syncFunctions}}public process_{{name}}(seqid: number, input: TProtocol, output: TProtocol, context?: any) {
         const args = new {{ServiceName}}{{nameTitleCase}}Args()
         args.read(input)
         input.readMessageEnd()
-        if (this._handler.{{name}}.length === {{argsLength}}) {
-            // TODO: Im a bit iffy on this
-            new Promise<{{typeName}}>((resolve, reject) => {
-                try {
-                    resolve(
-                        this._handler.{{name}}({{#args}}args.{{fieldName}}, {{/args}})
-                    )
-                } catch (e) {
-                    reject(e)
-                }
-            }).then((data: {{typeName}}) => {
-                const result = new {{ServiceName}}{{nameTitleCase}}Result({success: data})
+
+        new Promise<{{typeName}}>((resolve, reject) => {
+            try {
+                resolve(
+                    this._handler.{{name}}({{#args}}args.{{fieldName}}, {{/args}}context)
+                )
+            } catch (e) {
+                reject(e)
+            }
+        }).then((data: {{typeName}}) => {
+            const result = new {{ServiceName}}{{nameTitleCase}}Result({success: data})
+            output.writeMessageBegin("{{name}}", Thrift.MessageType.REPLY, seqid)
+            result.write(output)
+            output.writeMessageEnd()
+            output.flush()
+        }).catch((err: Error) => {
+            let result
+            {{#hasThrows}}{{#throws}}if (err instanceof {{throwType}}) {
+                result = new {{ServiceName}}{{nameTitleCase}}Result()
+                result.populate({{{throwName}}: err as {{throwType}}})
                 output.writeMessageBegin("{{name}}", Thrift.MessageType.REPLY, seqid)
-                result.write(output)
-                output.writeMessageEnd()
-                output.flush()
-            }).catch((err: Error) => {
-                let result
-                {{#hasThrows}}{{#throws}}if (err instanceof {{throwType}}) {
-                    result = new {{ServiceName}}{{nameTitleCase}}Result()
-                    result.populate({{{throwName}}: err as {{throwType}}})
-                    output.writeMessageBegin("{{name}}", Thrift.MessageType.REPLY, seqid)
-                } else {{/throws}}{
-                    result = new Thrift.TApplicationException(Thrift.TApplicationExceptionType.UNKNOWN, err.message)
-                    output.writeMessageBegin("{{name}}", Thrift.MessageType.EXCEPTION, seqid)
-                }
-                {{/hasThrows}}
-                {{^hasThrows}}
+            } else {{/throws}}{
                 result = new Thrift.TApplicationException(Thrift.TApplicationExceptionType.UNKNOWN, err.message)
                 output.writeMessageBegin("{{name}}", Thrift.MessageType.EXCEPTION, seqid)
-                {{/hasThrows}}
-                result.write(output)
-                output.writeMessageEnd()
-                output.flush()
-            })
-        } else {
-            this._handler.{{name}}({{#args}}args.{{fieldName}}, {{/args}}(err?: Error, data?: {{typeName}}) => {
-                let result
-                if (err == null) {
-                    result = new {{ServiceName}}{{nameTitleCase}}Result()
-                    result.populate((err != null ? err : {success: data}))
-                    output.writeMessageBegin("{{name}}", Thrift.MessageType.REPLY, seqid)
-                {{#throws}}} else if (err instanceof {{throwType}}) {
-                    result = new {{ServiceName}}{{nameTitleCase}}Result()
-                    result.populate({{{throwName}}: err as {{throwType}}})
-                    output.writeMessageBegin("{{name}}", Thrift.MessageType.REPLY, seqid)
-                {{/throws}}} else {
-                    result = new Thrift.TApplicationException(Thrift.TApplicationExceptionType.UNKNOWN, err.message)
-                    output.writeMessageBegin("{{name}}", Thrift.MessageType.EXCEPTION, seqid)
-                }
-                result.write(output)
-                output.writeMessageEnd()
-                output.flush()
-            })
-        }
+            }
+            {{/hasThrows}}
+            {{^hasThrows}}
+            result = new Thrift.TApplicationException(Thrift.TApplicationExceptionType.UNKNOWN, err.message)
+            output.writeMessageBegin("{{name}}", Thrift.MessageType.EXCEPTION, seqid)
+            {{/hasThrows}}
+            result.write(output)
+            output.writeMessageEnd()
+            output.flush()
+        })
+
     }
     {{/syncFunctions}}
 }

--- a/scrooge-generator/src/main/resources/nodegen/service.mustache
+++ b/scrooge-generator/src/main/resources/nodegen/service.mustache
@@ -7,6 +7,12 @@ import {Thrift, TProtocol, TTransport, Int64} from 'thrift'
 {{#resultStruct}}{{>struct}}{{/resultStruct}}
 {{/syncFunctionStructs}}
 
+export interface IService<Context> {
+    {{#syncFunctions}}
+        {{name}}: ({{#args}}{{fieldName}}: {{fieldType}}, {{/args}}context: Context): Promise<{{typeName}} | {{typeName}}
+    {{/syncFunctions}}
+}
+
 export class Client {
     private _seqid: number
     public _reqs: {[key: string]: (e?: Error|object, r?: any) => void}
@@ -80,10 +86,10 @@ export class Client {
 
 export class Processor<Context> {
 
-    constructor(private _handler) {
+    constructor(private _handler: IService<Context>) {
     }
 
-    public process(input: TProtocol, output: TProtocol, context?: Context) {
+    public process(input: TProtocol, output: TProtocol, context: Context) {
         const r = input.readMessageBegin()
         if (this["process_" + r.fname]) {
             return this["process_" + r.fname].call(this, r.rseqid, input, output, context)
@@ -99,7 +105,7 @@ export class Processor<Context> {
         }
     }
 
-    {{#syncFunctions}}public process_{{name}}(seqid: number, input: TProtocol, output: TProtocol, context?: Context) {
+    {{#syncFunctions}}public process_{{name}}(seqid: number, input: TProtocol, output: TProtocol, context: Context) {
         const args = new {{ServiceName}}{{nameTitleCase}}Args()
         args.read(input)
         input.readMessageEnd()

--- a/scrooge-generator/src/main/resources/nodegen/service.mustache
+++ b/scrooge-generator/src/main/resources/nodegen/service.mustache
@@ -7,12 +7,6 @@ import {Thrift, TProtocol, TTransport, Int64} from 'thrift'
 {{#resultStruct}}{{>struct}}{{/resultStruct}}
 {{/syncFunctionStructs}}
 
-export interface IService<Context> {
-    {{#syncFunctions}}
-        {{name}}: ({{#args}}{{fieldName}}: {{fieldType}}, {{/args}}context: Context): Promise<{{typeName}} | {{typeName}}
-    {{/syncFunctions}}
-}
-
 export class Client {
     private _seqid: number
     public _reqs: {[key: string]: (e?: Error|object, r?: any) => void}
@@ -86,7 +80,7 @@ export class Client {
 
 export class Processor<Context> {
 
-    constructor(private _handler: IService<Context>) {
+    constructor(private _handler) {
     }
 
     public process(input: TProtocol, output: TProtocol, context: Context) {


### PR DESCRIPTION
Post-pended an optional "context" parameter to every thrift method signature, allows service handlers to receive request context. The cleanest way to do this also required getting rid of callback signature support (returns void instead of a promise), but there doesn't seem to be a good reason to keep callback signatures around anyway - we may as well just always return a Promise.

The type of context is 'any', but it can always be cast to a framework-specific context.
